### PR TITLE
Fix the type declaration for the STREAM slot of MOVIE.

### DIFF
--- a/movie.lisp
+++ b/movie.lisp
@@ -27,7 +27,7 @@
 
 (genclass movie ()
 	  ((frames-counter 0 integer)
-	   (stream 0 stream)
+	   (stream nil (or null stream))
 	   ))
 
 (defgeneric add-to-movie (movie object)


### PR DESCRIPTION
The old initform, zero, was not compatible with the type, which is STREAM. Instead, use NIL as the initform and change the type to allow NIL.